### PR TITLE
Remove subpath for jupyter server, no longer needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Remove subpath for jupyter server, no longer needed [#2](https://github.com/nre-learning/antidote-images/pull/2)
 
 ## v0.4.0 - August 08, 2019
 

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p /opt/jupyterssl
 ENTRYPOINT ["tini", "-g", "--"]
 # CMD /usr/local/bin/start-notebook.sh --certfile=/opt/jupyterssl/fullchain.pem --keyfile=/opt/jupyterssl/privkey.pem --NotebookApp.base_url="/$SYRINGE_FULL_REF/"
 
-CMD /usr/local/bin/start-notebook.sh --NotebookApp.base_url="/$SYRINGE_FULL_REF/"
+CMD /usr/local/bin/start-notebook.sh --NotebookApp.base_url="/"
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER $NB_UID

--- a/jupyter/base-jupyter-config.py
+++ b/jupyter/base-jupyter-config.py
@@ -8,5 +8,6 @@ c.NotebookApp.password = ''
 
 c.NotebookApp.notebook_dir = '/antidote'
 
-# For embedding inside other pages
-c.NotebookApp.tornado_settings = { 'headers': { 'Content-Security-Policy': "frame-ancestors 'self' https://nrelabs.io/" } }
+# We need to do this since we want to permit the use of this inside an iframe
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
+c.NotebookApp.tornado_settings = { 'headers': { 'Content-Security-Policy': "frame-ancestors 'self' https://*.nrelabs.io/" } }

--- a/jupyter/base-jupyter-config.py
+++ b/jupyter/base-jupyter-config.py
@@ -9,4 +9,4 @@ c.NotebookApp.password = ''
 c.NotebookApp.notebook_dir = '/antidote'
 
 # For embedding inside other pages
-c.NotebookApp.tornado_settings = { 'headers': { 'Content-Security-Policy': "frame-ancestors 'self' https://labs.networkreliability.engineering/" } }
+c.NotebookApp.tornado_settings = { 'headers': { 'Content-Security-Policy': "frame-ancestors 'self' https://nrelabs.io/" } }


### PR DESCRIPTION
The [new model for provisioning ingresses](https://github.com/nre-learning/syringe/pull/151) that affect both endpoint `http` presentations, as well as Jupyter lab guides, makes it no longer necessary for endpoint images to jump through hoops to host their content on the appropriate sub-path. Instead, we can just host the Jupyter application at the root `/`, avoiding unnecessary complexity here.